### PR TITLE
Fix multi outputs forward bug

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -84,7 +84,7 @@ namespace mdl {
     }
 
     void forward_from_to_async(int pid, int inception_thread_num, int start, int end, vector<Layer *> layers) {
-        for (int i = start; i <= end; i++) {
+        for (int i = start; i < end; i++) {
             auto type = layers[i]->layer_type();
             if (type == Layer::_CONCAT) {
                 return;


### PR DESCRIPTION
When the net has multi outputs, the program crashes.